### PR TITLE
Fix version conflicts caused by PR#74

### DIFF
--- a/MariCommands.Tests/MariCommands.Tests.csproj
+++ b/MariCommands.Tests/MariCommands.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.TestHost from 3.1.7 to 5.0.8. [(PR#74)](https://github.com/MariBotOfficial/MariCommands/pull/74).
Hope this fix can help you.

Best regards,
sucrose